### PR TITLE
Add new Pea Car to vehicle list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `prc.api` is an asynchronous Python wrapper for the Police Roleplay Community (PRC) API.  
 It provides a convenient way to interact with PRC APIs, including the [private server APIs](https://apidocs.policeroleplay.community) for ER:LC.
 
-### 📖 [Documentation](https://github.com/Tycho-Systems/prc.api/wiki/Documentation)
+### 📖 [Documentation](https://github.com/Tycho-Systems/prc.api/wiki/Documentation) | [PyPI](https://pypi.org/project/prc.api)
 
 ## Features
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,22 +10,21 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, send an email to [contact@tycho.team](mailto:contact@tycho.team).
+Instead, send an email to [mail@tycho.team](mailto:mail@tycho.team).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Type of issue (e.g. buffer overflow, string injection, etc.)
 - Full paths of source file(s) related to the manifestation of the issue
 - The location of the affected source code (tag/branch/commit or direct URL)
 - Any special configuration required to reproduce the issue
 - Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
 - Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 
-## Preferred Languages
+## Preferred Language
 
 We prefer all communications to be in English.

--- a/prc/models/server/vehicle.py
+++ b/prc/models/server/vehicle.py
@@ -36,7 +36,7 @@ class Vehicle:
 
     @property
     def full_name(self) -> "VehicleName":
-        """The vehicle model name suffixed by the model year, if found."""
+        """The vehicle model name suffixed by the model year, if found. Unique for each game vehicle. A server may have multiple spawned vehicles with the same full name."""
         return f"{self.year or ''} {self.model}".strip()
 
 
@@ -51,6 +51,7 @@ VehicleName = Literal[
     "2016 Chevlon Amigo LZR",
     "1995 Leland Birchwood Hearse",
     "Lawn Mower",
+    "2025 Pea Car",
     "2003 Falcon Prime Eques",
     "2002 Chevlon Camion",
     "1995 Overland Apache",
@@ -225,6 +226,7 @@ VehicleModel = Literal[
     "Chevlon Amigo LZR",
     "Leland Birchwood Hearse",
     "Lawn Mower",
+    "Pea Car",
     "Falcon Prime Eques",
     "Chevlon Camion",
     "Overland Apache",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="prc.api",
-    version="0.2.3",
+    version="0.2.4",
     author="tycho",
     url="https://github.com/Tycho-Systems/prc.api",
     license="MIT",


### PR DESCRIPTION
Announced for April Fools 2025 (https://x.com/PRC_Roblox/status/1906822883252265094), the new Pea Car on the civilian team in ER:LC has been permanently added to the game as [confirmed by an announcement in the Discord server](https://discord.com/channels/505904189613015050/505904464931061761/1356513730934083697).