### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Tycho-Systems/prc.api/security/code-scanning/1](https://github.com/Tycho-Systems/prc.api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job to explicitly define the minimal permissions required. Since the `build` job only needs to read repository contents and upload artifacts, we will set `contents: read`. This ensures that the job has the least privileges necessary to perform its tasks.

The changes will be made in the `.github/workflows/release.yml` file, specifically within the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
